### PR TITLE
Fixes chef converge fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # atom CHANGELOG
 This file is used to list changes made in each version of the atom cookbook.
 
+## 0.4.1
+- Fix: use git resource to sync instead of execute to prevent chef from crashing when running converge
+
 ## 0.4.0
 - Feature: ability to specify plugins to clone from git
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'patrick@makestuffdostuff.com'
 license          'All rights reserved'
 description      'Installs/Configures atom'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.0'
+version          '0.4.1'
 
 depends 'chef_nginx', '~> 4.0.2'
 depends 'java', '~> 1.42.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -44,8 +44,7 @@ end
 
 # Clone plugins from git
 node['atom']['plugins'].each do |plugin|
-  execute "clone plugin from #{plugin}" do
-    cwd "#{node['atom']['install_dir']}/plugins/"
-    command "git clone #{plugin}"
+  git "#{node['atom']['install_dir']}/plugins/#{plugin['name']}" do
+    repository plugin['git_repo']
   end
 end


### PR DESCRIPTION
use git resource to sync instead of execute to prevent chef from crashing when running converge